### PR TITLE
Mold Repeater

### DIFF
--- a/clob/src/main/resources/clob-2seq.cmd
+++ b/clob/src/main/resources/clob-2seq.cmd
@@ -44,5 +44,5 @@ create inject01a com.core.clob.applications.utilities.ClobInjector @/bus INJ01
 inject01a/start
 #
 
-/busServer/setSessionSuffix AA
+/busServer/createSession AA
 seq01a/start

--- a/clob/src/main/resources/clob-backup.cmd
+++ b/clob/src/main/resources/clob-backup.cmd
@@ -29,3 +29,5 @@ ref01a/start
 # Backup Injector
 create inject01b com.core.clob.applications.utilities.ClobInjector @/bus INJ01
 #
+
+/bus/start

--- a/clob/src/main/resources/clob-primary.cmd
+++ b/clob/src/main/resources/clob-primary.cmd
@@ -34,5 +34,5 @@ create inject01a com.core.clob.applications.utilities.ClobInjector @/bus INJ01
 inject01a/start
 #
 
-/busServer/setSessionSuffix AA
+/busServer/createSession AA
 seq01a/start

--- a/clob/src/main/resources/clob-tier0.cmd
+++ b/clob/src/main/resources/clob-tier0.cmd
@@ -1,0 +1,21 @@
+#
+# usage: clob-tier0.cmd
+# description: demonstration of a clob inside the sequencer
+#
+
+source network-local.cmd
+source -s sysout-log.cmd
+source -s telnet.cmd inet:0.0.0.0:7001
+create /bus/schema com.core.clob.schema.ClobSchema
+
+# Primary Sequencer
+create /busServer/store com.core.platform.bus.mold.BufferChannelMessageStore
+create /busServer com.core.platform.bus.mold.MoldBusServer \
+    server @/bus/schema @/busServer/store $event_channel $command_channel $discovery_channel_tier0
+
+create seq01a com.core.platform.applications.sequencer.Sequencer @/busServer SEQ01
+create seq01a/handlers com.core.clob.applications.sequencer.ClobCommandHandlers @/busServer
+#
+
+/busServer/createSession AA
+seq01a/start

--- a/clob/src/main/resources/clob-tier1.cmd
+++ b/clob/src/main/resources/clob-tier1.cmd
@@ -1,0 +1,18 @@
+#
+# usage: clob-tier0.cmd
+# description: demonstration of a clob inside the sequencer
+#
+
+source network-local.cmd
+source -s sysout-log.cmd
+source -s telnet.cmd inet:0.0.0.0:7002
+create /bus/schema com.core.clob.schema.ClobSchema
+create /bus com.core.platform.bus.mold.MoldBusClient \
+    client @/bus/schema $event_channel $command_channel $discovery_channel_tier0
+
+# Rewinder
+create rewind01a com.core.platform.bus.mold.MoldRepeater REWIND01 @/bus $discovery_channel_tier1
+rewind01a/start
+#
+
+/bus/start

--- a/clob/src/main/resources/clob-tier2.cmd
+++ b/clob/src/main/resources/clob-tier2.cmd
@@ -1,23 +1,14 @@
 #
-# usage: clob.cmd
+# usage: clob-tier0.cmd
 # description: demonstration of a clob inside the sequencer
 #
 
 source network-local.cmd
 source -s sysout-log.cmd
-source -s telnet.cmd inet:0.0.0.0:7001
+source -s telnet.cmd inet:0.0.0.0:7003
 create /bus/schema com.core.clob.schema.ClobSchema
 create /bus com.core.platform.bus.mold.MoldBusClient \
-    client @/bus/schema $event_channel $command_channel $discovery_channel
-
-# Sequencer
-create /busServer/store com.core.platform.bus.mold.BufferChannelMessageStore
-create /busServer com.core.platform.bus.mold.MoldBusServer \
-    server @/bus/schema @/busServer/store $event_channel $command_channel $discovery_channel
-
-create seq01a com.core.platform.applications.sequencer.Sequencer @/busServer SEQ01
-create seq01a/handlers com.core.clob.applications.sequencer.ClobCommandHandlers @/busServer
-#
+    client @/bus/schema $event_channel $command_channel $discovery_channel_tier1
 
 # Reference Data Publisher
 create ref01a com.core.platform.applications.refdata.ReferenceDataPublisher @/bus REF01 equityDefinition
@@ -35,5 +26,4 @@ create inject01a com.core.clob.applications.utilities.ClobInjector @/bus INJ01
 inject01a/start
 #
 
-/busServer/createSession AA
-seq01a/start
+/bus/start

--- a/platform/src/main/java/com/core/platform/bus/mold/MoldBusClient.java
+++ b/platform/src/main/java/com/core/platform/bus/mold/MoldBusClient.java
@@ -190,7 +190,6 @@ public class MoldBusClient<DispatcherT extends Dispatcher, ProviderT extends Pro
         encoder.openMap()
                 .string("eventReceiver").object(eventReceiver)
                 .string("commandProviders").number(nameToCommandProviders.size())
-                .string("activator").object(activator)
                 .closeMap();
     }
 

--- a/platform/src/main/java/com/core/platform/bus/mold/MoldBusServer.java
+++ b/platform/src/main/java/com/core/platform/bus/mold/MoldBusServer.java
@@ -281,8 +281,8 @@ public class MoldBusServer<DispatcherT extends Dispatcher, ProviderT extends Pro
      * @throws IllegalArgumentException if {@code sessionSuffix} is not 2 bytes
      */
     @Command
-    public void setSessionSuffix(DirectBuffer sessionSuffix) {
-        session.setSessionSuffix(sessionSuffix);
+    public void createSession(DirectBuffer sessionSuffix) {
+        session.create(sessionSuffix);
     }
 
     @Override

--- a/platform/src/main/java/com/core/platform/bus/mold/MoldRepeater.java
+++ b/platform/src/main/java/com/core/platform/bus/mold/MoldRepeater.java
@@ -1,0 +1,105 @@
+package com.core.platform.bus.mold;
+
+import com.core.infrastructure.buffer.BufferUtils;
+import com.core.infrastructure.command.Command;
+import com.core.infrastructure.command.Directory;
+import com.core.infrastructure.encoding.Encodable;
+import com.core.infrastructure.encoding.ObjectEncoder;
+import com.core.infrastructure.io.Selector;
+import com.core.infrastructure.log.LogFactory;
+import com.core.platform.activation.Activatable;
+import com.core.platform.activation.Activator;
+import com.core.platform.activation.ActivatorFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * The {@code MoldRepeater} application services rewind requests over the MoldUDP64 protocol.
+ *
+ * <p>The MoldUDP64 protocol is located on the
+ * <a href="https://www.nasdaqtrader.com/content/technicalsupport/specifications/dataproducts/moldudp64.pdf">Nasdaq
+ * website</a>
+ *
+ * <h2>Activation</h2>
+ *
+ * <p>The application has the following activation dependencies:
+ * <ul>
+ *     <li>the Mold session has been defined
+ *     <li>the Discovery channel socket is open
+ *     <li>the Rewind channel socket is open
+ * </ul>
+ *
+ * <p>On activation, the application will:
+ * <ul>
+ *     <li>service discovery requests
+ *     <li>service rewind requests
+ * </ul>
+ *
+ * <p>On deactivation, the application will:
+ * <ul>
+ *     <li>stop servicing discovery requests
+ *     <li>stop servicing rewind requests
+ * </ul>
+ */
+public class MoldRepeater implements Activatable, Encodable {
+
+    private final MoldRewinder rewinder;
+    @Directory(path = ".")
+    private final Activator activator;
+
+    /**
+     * Creates a {@code MoldRepeater} from the specified parameters.
+     * An empty index file and a message file are created with the specified {@code name}.
+     *
+     * @param selector the NIO selector
+     * @param logFactory the factory to create logs
+     * @param activatorFactory the factory to create activators
+     * @param name a unique name for the rewinder
+     * @param busClient the bus client
+     * @param address the multicast address to listen to discovery requests on
+     * @throws IOException if an I/O error occurs creating the index or message file
+     */
+    public MoldRepeater(
+            Selector selector, LogFactory logFactory, ActivatorFactory activatorFactory,
+            String name, MoldBusClient<?, ?> busClient, String address)
+                throws IOException {
+        var messageStore = new FileChannelMessageStore(Path.of("."));
+        messageStore.open(BufferUtils.fromAsciiString(name));
+
+        rewinder = new MoldRewinder(
+                "MoldRewinder:" + name, selector, logFactory, activatorFactory,
+                busClient.getMoldSession(), messageStore, address);
+        activator = activatorFactory.createActivator(name, this, rewinder);
+        activator.ready();
+
+        var lengths = new int[1];
+        busClient.getDispatcher().addListenerBeforeDispatch(decoder -> {
+            try {
+                var buffer = messageStore.acquire();
+                buffer.putShort(0, (short) decoder.length());
+                buffer.putBytes(Short.BYTES, decoder.buffer(), decoder.offset(), decoder.length());
+                lengths[0] = Short.BYTES + decoder.length();
+                messageStore.commit(lengths, 0, 1);
+            } catch (IOException e) {
+                activator.notReady("I/O error");
+            }
+        });
+    }
+
+    @Override
+    public void activate() {
+        activator.ready();
+    }
+
+    @Override
+    public void deactivate() {
+        activator.notReady();
+    }
+
+    @Command(path = "status", readOnly = true)
+    @Override
+    public void encode(ObjectEncoder encoder) {
+        encoder.object(rewinder);
+    }
+}

--- a/platform/src/main/java/com/core/platform/bus/mold/MoldRewinder.java
+++ b/platform/src/main/java/com/core/platform/bus/mold/MoldRewinder.java
@@ -1,6 +1,8 @@
 package com.core.platform.bus.mold;
 
 import com.core.infrastructure.buffer.BufferUtils;
+import com.core.infrastructure.encoding.Encodable;
+import com.core.infrastructure.encoding.ObjectEncoder;
 import com.core.infrastructure.io.DatagramChannel;
 import com.core.infrastructure.io.Selector;
 import com.core.infrastructure.log.Log;
@@ -15,7 +17,7 @@ import java.io.IOException;
 import java.net.StandardSocketOptions;
 import java.util.Objects;
 
-class MoldRewinder implements Activatable {
+class MoldRewinder implements Encodable, Activatable {
 
     private final Selector selector;
     private final String discoveryChannelAddress;
@@ -172,5 +174,14 @@ class MoldRewinder implements Activatable {
             log.warn().append("error reading rewind socket, closing: ").append(e).commit();
             activator.stop();
         }
+    }
+
+    @Override
+    public void encode(ObjectEncoder encoder) {
+        encoder.openMap()
+                .string("discovery").object(discoveryChannelSocket)
+                .string("rewind").object(rewindSocket)
+                .string("store").object(messageStore)
+                .closeMap();
     }
 }

--- a/platform/src/main/java/com/core/platform/bus/mold/MoldSession.java
+++ b/platform/src/main/java/com/core/platform/bus/mold/MoldSession.java
@@ -6,7 +6,6 @@ import com.core.infrastructure.command.Command;
 import com.core.infrastructure.encoding.Encodable;
 import com.core.infrastructure.encoding.ObjectEncoder;
 import com.core.infrastructure.time.Time;
-import com.core.platform.activation.Activatable;
 import com.core.platform.activation.Activator;
 import com.core.platform.activation.ActivatorFactory;
 import org.agrona.DirectBuffer;
@@ -28,7 +27,7 @@ import java.util.concurrent.TimeUnit;
  * Where {@code yyyyMMdd} is the date the session was created. and {@code XX} is the two-letter user-defined suffix for
  * the session.
  */
-class MoldSession implements Activatable, Encodable {
+class MoldSession implements Encodable {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
@@ -38,7 +37,6 @@ class MoldSession implements Activatable, Encodable {
     private DirectBuffer sessionName;
     private String sessionNameString;
     private long nextSessionSeqNum;
-    private DirectBuffer sessionSuffix;
 
     /**
      * Creates the {@code MoldSession} with the specified {@code time} object that is used to query the current date
@@ -53,17 +51,6 @@ class MoldSession implements Activatable, Encodable {
         nextSessionSeqNum = 1;
         activator = activatorFactory.createActivator(name, this);
         openSessionListeners = new CoreList<>();
-    }
-
-    /**
-     * Initializes the session suffix.
-     * The session will be created when the
-     *
-     * @param sessionSuffix the suffix of the session
-     */
-    @Command
-    public void setSessionSuffix(DirectBuffer sessionSuffix) {
-        this.sessionSuffix = BufferUtils.copy(sessionSuffix);
     }
 
     /**
@@ -156,22 +143,6 @@ class MoldSession implements Activatable, Encodable {
             throw new IllegalStateException(
                     "session is already defined: " + BufferUtils.toAsciiString(sessionName));
         }
-    }
-
-    @Override
-    public void activate() {
-        if (sessionSuffix == null) {
-            throw new IllegalStateException("sessionSuffix not set");
-        }
-        create(sessionSuffix);
-    }
-
-    DirectBuffer getSessionSuffix() {
-        return sessionSuffix;
-    }
-
-    @Override
-    public void deactivate() {
     }
 
     @Override

--- a/platform/src/main/java/com/core/platform/bus/playback/FilePlayback.java
+++ b/platform/src/main/java/com/core/platform/bus/playback/FilePlayback.java
@@ -338,6 +338,7 @@ public class FilePlayback<DispatcherT extends Dispatcher, ProviderT extends Prov
         public void addCloseSessionListener(Runnable listener) {
             closeListeners.add(listener);
         }
+
     }
 
     private class FileMessagePublisher implements MessagePublisher, Activatable {

--- a/platform/src/main/java/com/core/platform/bus/playback/FilePlayback.java
+++ b/platform/src/main/java/com/core/platform/bus/playback/FilePlayback.java
@@ -338,7 +338,6 @@ public class FilePlayback<DispatcherT extends Dispatcher, ProviderT extends Prov
         public void addCloseSessionListener(Runnable listener) {
             closeListeners.add(listener);
         }
-
     }
 
     private class FileMessagePublisher implements MessagePublisher, Activatable {

--- a/platform/src/main/java/com/core/platform/bus/playback/ReadOnlyFilePlayback.java
+++ b/platform/src/main/java/com/core/platform/bus/playback/ReadOnlyFilePlayback.java
@@ -269,5 +269,6 @@ public class ReadOnlyFilePlayback implements Consumer<String> {
         public void addCloseSessionListener(Runnable listener) {
             closeListeners.add(listener);
         }
+
     }
 }

--- a/platform/src/main/java/com/core/platform/bus/playback/ReadOnlyFilePlayback.java
+++ b/platform/src/main/java/com/core/platform/bus/playback/ReadOnlyFilePlayback.java
@@ -269,6 +269,5 @@ public class ReadOnlyFilePlayback implements Consumer<String> {
         public void addCloseSessionListener(Runnable listener) {
             closeListeners.add(listener);
         }
-
     }
 }

--- a/platform/src/main/resources/network-local.cmd
+++ b/platform/src/main/resources/network-local.cmd
@@ -1,3 +1,5 @@
 set event_channel inet:239.100.100.100:10100:lo0
 set command_channel inet:239.100.100.101:10101:lo0
-set discovery_channel inet:239.100.100.102:10102:lo0
+set discovery_channel_tier0 inet:239.100.100.102:10102:lo0
+set discovery_channel_tier1 inet:239.100.100.102:10103:lo0
+set discovery_channel $discovery_channel_tier1


### PR DESCRIPTION
Added a MoldUDP Repeater application to service rewind requests to applications and free up the Sequencer from this task. This is designed for a three tier setup with the Sequencer (tier 0) servicing rewind requests from Repeater applications (tier 1) which in turn service rewind requests from regular applications (tier 2). There are three example files to demonstrate: clob-tier0.cmd, clob-tier1.cmd, and clob-tier2.cmd. Run them in separate VMs.

Changed the MoldSession to be non-activatable. This removes redundant internal state inside the object.

Additionally, the MoldClientBus is now explicitly opened at the end of command files. This makes it so it is not dependent on an ancestor application happening to set the bus active.